### PR TITLE
Add newly added notification types

### DIFF
--- a/appstore/notification.go
+++ b/appstore/notification.go
@@ -23,6 +23,10 @@ const (
 	NotificationTypeDidFailToRenew NotificationType = "DID_FAIL_TO_RENEW"
 	// AppleCare successfully refunded the transaction for a consumable, non-consumable, or a non-renewing subscription
 	NotificationTypeRefund NotificationType = "REFUND"
+	// App Store has started asking the customer to consent to your app’s subscription price increase
+	NotificationTypePriceIncreaseConsent NotificationType = "PRICE_INCREASE_CONSENT"
+	// Customer’s subscription has successfully auto-renewed for a new transaction period.
+	NotificationTypeDidRenew NotificationType = "DID_RENEW"
 )
 
 type NotificationEnvironment string


### PR DESCRIPTION
App store has recently added two new notifications:

```
**PRICE_INCREASE_CONSENT**
You’ve increased the price of a subscription, and the customer must agree to the increase before the subscription auto-renews

**DID_RENEW**
Subscription succesfully auto-renewed
```

https://developer.apple.com/documentation/appstoreservernotifications/notification_type