### PR TITLE
IAP-259: Add omitempty to the original transaction id

### DIFF
--- a/appstore/model.go
+++ b/appstore/model.go
@@ -88,7 +88,7 @@ type (
 		Quantity                    string        `json:"quantity"`
 		ProductID                   string        `json:"product_id"`
 		TransactionID               string        `json:"transaction_id"`
-		OriginalTransactionID       numericString `json:"original_transaction_id"`
+		OriginalTransactionID       numericString `json:"original_transaction_id,omitempty"`
 		WebOrderLineItemID          string        `json:"web_order_line_item_id,omitempty"`
 		PromotionalOfferID          string        `json:"promotional_offer_id"`
 		SubscriptionGroupIdentifier string        `json:"subscription_group_identifier"`
@@ -181,7 +181,7 @@ type (
 		ItemID               string `json:"item_id"`
 		ProductID            string `json:"product_id"`
 		PurchaseDate
-		OriginalTransactionID numericString `json:"original_transaction_id"`
+		OriginalTransactionID numericString `json:"original_transaction_id,omitempty"`
 		OriginalPurchaseDate
 		Quantity                  string        `json:"quantity"`
 		TransactionID             string        `json:"transaction_id"`

--- a/appstore/notification.go
+++ b/appstore/notification.go
@@ -54,7 +54,7 @@ type NotificationReceipt struct {
 	BID                       string        `json:"bid"`
 	BVRS                      string        `json:"bvrs"`
 	TransactionID             string        `json:"transaction_id"`
-	OriginalTransactionID     numericString `json:"original_transaction_id"`
+	OriginalTransactionID     numericString `json:"original_transaction_id,omitempty"`
 	IsTrialPeriod             string        `json:"is_trial_period"`
 	IsInIntroOfferPeriod      string        `json:"is_in_intro_offer_period"`
 
@@ -78,7 +78,7 @@ type SubscriptionNotification struct {
 
 	// Not show in raw notify body
 	Password              string        `json:"password"`
-	OriginalTransactionID numericString `json:"original_transaction_id"`
+	OriginalTransactionID numericString `json:"original_transaction_id,omitempty"`
 	AutoRenewAdamID       string        `json:"auto_renew_adam_id"`
 
 	// The primary key for identifying a subscription purchase.


### PR DESCRIPTION
IAP-259:
Apple only sends fields with data in them; they don't send empty fields. When the json is unmarshaled into the SubscriptionNotification struct, all fields are created including the original transaction id with a numericString type. An empty string cannot be unmarshaled preventing dead q items from being processed as the struct is marshaled into json with the original_transaction_id set to "".

Add omitempty to prevent these fields from being included