### PR TITLE
QE-2168: Make the type numericString exportable in Enflick/go-iap/appstore/model.go

### DIFF
--- a/appstore/model.go
+++ b/appstore/model.go
@@ -2,14 +2,15 @@ package appstore
 
 import "encoding/json"
 
-type numericString string
+// NumericString is used to represent the Original Transaction ID
+type NumericString string
 
-func (n *numericString) UnmarshalJSON(b []byte) error {
+func (n *NumericString) UnmarshalJSON(b []byte) error {
 	var number json.Number
 	if err := json.Unmarshal(b, &number); err != nil {
 		return err
 	}
-	*n = numericString(number.String())
+	*n = NumericString(number.String())
 	return nil
 }
 
@@ -87,9 +88,9 @@ type (
 	InApp struct {
 		Quantity                    string        `json:"quantity"`
 		ProductID                   string        `json:"product_id"`
-		TransactionID               string        `json:"transaction_id"`
-		OriginalTransactionID       numericString `json:"original_transaction_id,omitempty"`
-		WebOrderLineItemID          string        `json:"web_order_line_item_id,omitempty"`
+		TransactionID         string        `json:"transaction_id"`
+		OriginalTransactionID NumericString `json:"original_transaction_id,omitempty"`
+		WebOrderLineItemID    string        `json:"web_order_line_item_id,omitempty"`
 		PromotionalOfferID          string        `json:"promotional_offer_id"`
 		SubscriptionGroupIdentifier string        `json:"subscription_group_identifier"`
 
@@ -110,11 +111,11 @@ type (
 	Receipt struct {
 		ReceiptType                string        `json:"receipt_type"`
 		AdamID                     int64         `json:"adam_id"`
-		AppItemID                  numericString `json:"app_item_id"`
+		AppItemID                  NumericString `json:"app_item_id"`
 		BundleID                   string        `json:"bundle_id"`
 		ApplicationVersion         string        `json:"application_version"`
 		DownloadID                 int64         `json:"download_id"`
-		VersionExternalIdentifier  numericString `json:"version_external_identifier"`
+		VersionExternalIdentifier  NumericString `json:"version_external_identifier"`
 		OriginalApplicationVersion string        `json:"original_application_version"`
 		InApp                      []InApp       `json:"in_app"`
 		ReceiptCreationDate
@@ -171,7 +172,7 @@ type (
 	}
 
 	ReceiptForIOS6 struct {
-		AppItemID numericString `json:"app_item_id"`
+		AppItemID NumericString `json:"app_item_id"`
 		BID       string        `json:"bid"`
 		BVRS      string        `json:"bvrs"`
 		CancellationDate
@@ -181,13 +182,13 @@ type (
 		ItemID               string `json:"item_id"`
 		ProductID            string `json:"product_id"`
 		PurchaseDate
-		OriginalTransactionID numericString `json:"original_transaction_id,omitempty"`
+		OriginalTransactionID NumericString `json:"original_transaction_id,omitempty"`
 		OriginalPurchaseDate
 		Quantity                  string        `json:"quantity"`
 		TransactionID             string        `json:"transaction_id"`
 		UniqueIdentifier          string        `json:"unique_identifier"`
 		UniqueVendorIdentifier    string        `json:"unique_vendor_identifier"`
-		VersionExternalIdentifier numericString `json:"version_external_identifier,omitempty"`
+		VersionExternalIdentifier NumericString `json:"version_external_identifier,omitempty"`
 		WebOrderLineItemID        string        `json:"web_order_line_item_id"`
 	}
 )

--- a/appstore/model_test.go
+++ b/appstore/model_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNumericString_UnmarshalJSON(t *testing.T) {
 	type foo struct {
-		ID numericString
+		ID NumericString
 	}
 
 	tests := []struct {

--- a/appstore/notification.go
+++ b/appstore/notification.go
@@ -53,9 +53,9 @@ type NotificationReceipt struct {
 	ProductID                 string        `json:"product_id"`
 	BID                       string        `json:"bid"`
 	BVRS                      string        `json:"bvrs"`
-	TransactionID             string        `json:"transaction_id"`
-	OriginalTransactionID     numericString `json:"original_transaction_id,omitempty"`
-	IsTrialPeriod             string        `json:"is_trial_period"`
+	TransactionID         string        `json:"transaction_id"`
+	OriginalTransactionID NumericString `json:"original_transaction_id,omitempty"`
+	IsTrialPeriod         string        `json:"is_trial_period"`
 	IsInIntroOfferPeriod      string        `json:"is_in_intro_offer_period"`
 
 	PurchaseDate
@@ -78,7 +78,7 @@ type SubscriptionNotification struct {
 
 	// Not show in raw notify body
 	Password              string        `json:"password"`
-	OriginalTransactionID numericString `json:"original_transaction_id,omitempty"`
+	OriginalTransactionID NumericString `json:"original_transaction_id,omitempty"`
 	AutoRenewAdamID       string        `json:"auto_renew_adam_id"`
 
 	// The primary key for identifying a subscription purchase.


### PR DESCRIPTION
This change is to make the `numericString` type exportable that is in  `Enflick/go-iap/appstore/model.go`. For more details as to the reasoning behind it please see [QE-2168](https://textnow.atlassian.net/browse/QE-2168)